### PR TITLE
Fix for latest React Router Beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "preact-router": "^2.0.0",
     "promise-polyfill": "^6.0.2",
     "proptypes": "^0.14.3",
-    "react-router": "4",
-    "react-router-dom": "beta",
+    "react-router": "4.0.0-beta.7",
+    "react-router-dom": "4.0.0-beta.7",
     "serve": "^2.0.0"
   }
 }

--- a/src/lib/react.js
+++ b/src/lib/react.js
@@ -14,7 +14,7 @@ options.vnode = vnode => {
 	if (old) old(vnode);
 };
 
-const Children = { only: c => c[0] };
+const Children = { only: c => c[0], count: c => c.length };
 
 export { createElement, Children, PropTypes, Component };
 export default { createElement, Children, PropTypes, Component };


### PR DESCRIPTION
Was just playing around with this and noticed it was broken on the latest RR beta as it uses `Children.count` which i've mocked here.