### PR TITLE
Update to react-router 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "core-js": "^2.4.1",
     "cross-env": "^3.1.3",
     "css-loader": "^0.26.1",
-    "eslint": "^3.0.1",
+    "eslint": "^3.19.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "html-webpack-plugin": "^2.22.0",
@@ -74,11 +74,10 @@
     "preact": "beta",
     "preact-compat": "^3.0.0",
     "preact-render-to-string": "^3.5.0",
-    "preact-router": "^2.0.0",
     "promise-polyfill": "^6.0.2",
     "proptypes": "^0.14.3",
-    "react-router": "4.0.0-beta.7",
-    "react-router-dom": "4.0.0-beta.7",
+    "react-router": "4.1.1",
+    "react-router-dom": "4.1.1",
     "serve": "^2.0.0"
   }
 }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 import Router from 'react-router-dom/BrowserRouter';
-import Route from 'react-router/Route';
+import { Route, Switch } from 'react-router';
 import Header from './header';
 import Home from './home';
 import Profile from './profile';
@@ -11,9 +11,11 @@ export default class App extends Component {
 			<Router>
 				<div id="app">
 					<Header />
-					<Route component={Home} exact path="/" />
-					<Route component={Profile} exact path="/profile/" user="me" />
-					<Route component={Profile} exact path="/profile/:user" />
+					<Switch>
+						<Route component={Home} path="/" />
+					</Switch>
+					<Route exact component={Profile} path="/profile/" user="me" />
+					<Route exact component={Profile} path="/profile/:user" />
 				</div>
 			</Router>
 		);

--- a/src/lib/react.js
+++ b/src/lib/react.js
@@ -5,7 +5,7 @@
  *		- vnode.children deleted when empty
  */
 
-import { h as createElement, Component, options } from 'preact';
+import { h as createElement, cloneElement, Component, options } from 'preact';
 import PropTypes from 'proptypes';
 
 let old = options.vnode;
@@ -14,7 +14,22 @@ options.vnode = vnode => {
 	if (old) old(vnode);
 };
 
-const Children = { only: c => c[0], count: c => c.length };
+const childrenForEach = (children, cb) =>
+	Array.isArray(children) && children.forEach((VNode) => {
+		// this is gross, send help
+		VNode.props = VNode.attributes;
+		cb(VNode);
+		delete VNode.props;
+	});
 
-export { createElement, Children, PropTypes, Component };
-export default { createElement, Children, PropTypes, Component };
+const Children = {
+	count: c => c.length,
+	forEach: childrenForEach,
+	only: c => c[0]
+};
+
+// TODO
+const isValidElement = (element) => true;
+
+export { createElement, cloneElement, isValidElement, Children, PropTypes, Component };
+export default { createElement, cloneElement, isValidElement, Children, PropTypes, Component };

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -104,11 +104,11 @@ module.exports = {
 	]).concat( ENV==='production' ? [
 		new ReplacePlugin([
 			{
-				partten: /throw\s+(new\s+)?[a-zA-Z]+Error\s*\(/g,
+				pattern: /throw\s+(new\s+)?[a-zA-Z]+Error\s*\(/g,
 				replacement: (s) => 'throw 0;'+s
 			},
 			{
-				partten: /\binvariant\s\(/g,
+				pattern: /\binvariant\s\(/g,
 				replacement: () => '('
 			}
 		]),


### PR DESCRIPTION
Hey @developit this continues the discussion from Twitter. Could be a decent test bed for that alias "mixin".

What this did:
Need to alias `cloneElement`, `Children.forEach`, and `isValidElement`.

Not entirely what the best approach for `forEach` is.
Haven't looked into a `preact` version of `isValidElement`.

Also this uses a `<Switch/>` just to test if it runs.

Todo:
- [ ] fix routing
- [ ] figure out correct `Children.forEach` implementation
- [ ] figure out correct `isValidElement` implementation